### PR TITLE
Version2 iframes for agent redesign

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1101,6 +1101,81 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@elastic/react-search-ui": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui/-/react-search-ui-1.5.1.tgz",
+      "integrity": "sha512-SI7uOF+jI+Z2D+2otym+4eLBYnocmxa+NA6VPSBrADZXyn8oUEzA4MBtJtxHLtcj64Tj8Riv0tw3t9q3b8iF+w==",
+      "requires": {
+        "@elastic/react-search-ui-views": "1.5.1",
+        "@elastic/search-ui": "1.5.1"
+      }
+    },
+    "@elastic/react-search-ui-views": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui-views/-/react-search-ui-views-1.5.1.tgz",
+      "integrity": "sha512-x4X2xc/69996IEId3VVBTwPICnx/sschnfQ6YmuU3+myRa+VUPkkAWIK/cBcyBW8TNsLtZHWZrjQYi24+H7YWA==",
+      "requires": {
+        "downshift": "^3.2.10",
+        "rc-pagination": "^1.20.1",
+        "react-select": "^2.4.4"
+      }
+    },
+    "@elastic/search-ui": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@elastic/search-ui/-/search-ui-1.5.1.tgz",
+      "integrity": "sha512-ssfvX1q76X1UwqYASWtBni4PZ+3SYk1PvHmOjpVf9BYai1OqZLGVaj8Sw+cE1ia56zl5In7viCfciC+CP31ovA==",
+      "requires": {
+        "date-fns": "^1.30.1",
+        "deep-equal": "^1.0.1",
+        "history": "^4.9.0",
+        "qs": "^6.7.0"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        }
+      }
+    },
+    "@elastic/search-ui-site-search-connector": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@elastic/search-ui-site-search-connector/-/search-ui-site-search-connector-1.5.1.tgz",
+      "integrity": "sha512-SwQ6NGyrSAHNXNPlmJMQd/RtIxhQfJ9NIYMrjVIweRNZ9BWwnlDgDbnPWH0fXd+q6TFCg3ZEDjMV5PaMamErAg=="
+    },
+    "@emotion/babel-utils": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
+      "integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
+      "requires": {
+        "@emotion/hash": "^0.6.6",
+        "@emotion/memoize": "^0.6.6",
+        "@emotion/serialize": "^0.9.1",
+        "convert-source-map": "^1.5.1",
+        "find-root": "^1.1.0",
+        "source-map": "^0.7.2"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+          "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
+      "integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
+    },
     "@emotion/is-prop-valid": {
       "version": "0.8.6",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.6.tgz",
@@ -1114,6 +1189,29 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
+    "@emotion/serialize": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
+      "integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
+      "requires": {
+        "@emotion/hash": "^0.6.6",
+        "@emotion/memoize": "^0.6.6",
+        "@emotion/unitless": "^0.6.7",
+        "@emotion/utils": "^0.8.2"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+          "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
+        },
+        "@emotion/unitless": {
+          "version": "0.6.7",
+          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
+          "integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
+        }
+      }
+    },
     "@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
@@ -1123,6 +1221,11 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
+      "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -1346,20 +1449,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "@material/button": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@material/button/-/button-3.2.0.tgz",
-      "integrity": "sha512-VEASy3Dtc7BCo8/cuUIp6w0+/l4U1myGZffK5GeFVInP/erStSQOmYXT7jGXkZpUglRzWOpVvEpc6nsvhMqGbw==",
-      "requires": {
-        "@material/elevation": "^3.1.0",
-        "@material/feature-targeting": "^3.1.0",
-        "@material/ripple": "^3.2.0",
-        "@material/rtl": "^3.2.0",
-        "@material/shape": "^3.1.0",
-        "@material/theme": "^3.1.0",
-        "@material/typography": "^3.1.0"
-      }
-    },
     "@material/density": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material/density/-/density-5.1.0.tgz",
@@ -1371,16 +1460,6 @@
       "integrity": "sha512-RtBLSkrBjMfHwknaGBifAIC8cBWF9pXjz2IYqfI2braB6SfQI4vhdJviwyiA5BmA/psn3cKpBUZbHI0ym0O0SQ==",
       "requires": {
         "tslib": "^1.9.3"
-      }
-    },
-    "@material/elevation": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-3.1.0.tgz",
-      "integrity": "sha512-e45LqiG6LfbR1M52YkSLA7pQPeYJOuOVzLp27xy2072TnLuJexMxhEaG4O1novEIjsTtMjqfrfJ/koODU5vEew==",
-      "requires": {
-        "@material/animation": "^3.1.0",
-        "@material/feature-targeting": "^3.1.0",
-        "@material/theme": "^3.1.0"
       }
     },
     "@material/feature-targeting": {
@@ -1532,41 +1611,87 @@
       }
     },
     "@netdata/netdata-ui": {
-      "version": "0.7.23",
-      "resolved": "https://registry.npmjs.org/@netdata/netdata-ui/-/netdata-ui-0.7.23.tgz",
-      "integrity": "sha512-f+31ZflvOTatWXRKKytD6Ch9M9HzIuMYUex7kQRVUtLGSgBxH47cI+k1pf2lnllYQDE7BF09w0YJ5piTH9mI2Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@netdata/netdata-ui/-/netdata-ui-1.4.3.tgz",
+      "integrity": "sha512-vJKgx1NACEpoebuET55XUYNXr68c3ONzAqMNxtwA9/c6y1NGM1GDokVbr777i0COwFY3X2YNuoEn652oc5wm/g==",
       "requires": {
-        "@rmwc/button": "^5.7",
-        "@rmwc/circular-progress": "^5.7",
-        "polished": "^3.4.1",
-        "ramda": "^0.26.1",
+        "@elastic/react-search-ui": "^1.5.1",
+        "@elastic/search-ui-site-search-connector": "^1.5.1",
+        "@netdata/react-filter-box": "^1.0.0",
+        "polished": "^4.0.3",
+        "ramda": "^0.27.1",
+        "react-beautiful-dnd": "^13.0.0",
         "react-portal": "^4.2.0",
-        "react-table": "^7.0.0-rc.15",
-        "react-use": "^12.7.1"
+        "react-table": "^7.2.1",
+        "react-use": "^15.3.4",
+        "react-window": "^1.8.5"
       },
       "dependencies": {
+        "@types/js-cookie": {
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.6.tgz",
+          "integrity": "sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw=="
+        },
+        "@xobotyi/scrollbar-width": {
+          "version": "1.9.5",
+          "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+          "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
         "ramda": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-          "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
+          "version": "0.27.1",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+          "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
         },
         "react-use": {
-          "version": "12.13.0",
-          "resolved": "https://registry.npmjs.org/react-use/-/react-use-12.13.0.tgz",
-          "integrity": "sha512-Kh0m9ezIn9xfRycx4jdAgvsYGstGfjTBO2ecIM3+G0RqrpMxTIL5jjYraHYfUzjGBHf7dUhNYBzm5vw5LItVZA==",
+          "version": "15.3.8",
+          "resolved": "https://registry.npmjs.org/react-use/-/react-use-15.3.8.tgz",
+          "integrity": "sha512-GeGcrmGuUvZrY5wER3Lnph9DSYhZt5nEjped4eKDq8BRGr2CnLf9bDQWG9RFc7oCPphnscUUdOovzq0E5F2c6Q==",
           "requires": {
-            "@types/react-wait": "^0.3.0",
-            "copy-to-clipboard": "^3.1.0",
-            "nano-css": "^5.1.0",
-            "react-fast-compare": "^2.0.4",
-            "react-wait": "^0.3.0",
+            "@types/js-cookie": "2.2.6",
+            "@xobotyi/scrollbar-width": "1.9.5",
+            "copy-to-clipboard": "^3.2.0",
+            "fast-deep-equal": "^3.1.3",
+            "fast-shallow-equal": "^1.0.0",
+            "js-cookie": "^2.2.1",
+            "nano-css": "^5.2.1",
+            "react-universal-interface": "^0.6.2",
             "resize-observer-polyfill": "^1.5.1",
             "screenfull": "^5.0.0",
             "set-harmonic-interval": "^1.0.1",
-            "throttle-debounce": "^2.0.1",
+            "throttle-debounce": "^2.1.0",
             "ts-easing": "^0.2.0",
-            "tslib": "^1.10.0"
+            "tslib": "^2.0.0"
           }
+        },
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
+    "@netdata/react-filter-box": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@netdata/react-filter-box/-/react-filter-box-1.0.0.tgz",
+      "integrity": "sha512-mYgllJ6r8SabpLinh7q5rnIiCg7BQ0vXPvjq9eve8lHPLGhsA/CB4omBSe5v4L/t5MDlkWib7qc/1aRiiOJqLg==",
+      "requires": {
+        "codemirror": "^5.42.0",
+        "lodash": "^4.17.19",
+        "pegjs": "^0.10.0",
+        "react": "^16.6.3",
+        "react-codemirror2": "^5.1.0",
+        "react-dom": "^16.6.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -1585,28 +1710,6 @@
         "focus-trap": "^5.0.0",
         "hyperform": "^0.9.9",
         "mutation-observer": "^1.0.3"
-      }
-    },
-    "@rmwc/button": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@rmwc/button/-/button-5.7.2.tgz",
-      "integrity": "sha512-Kerzok5q4wxB8Kj4BgckG54r0/nruq+eUK4+rujMiBRIUPi1nw47OZCab8/c+T+bsyVTnBOcXW+xwcmPG6dCXQ==",
-      "requires": {
-        "@material/button": "^3.1.0",
-        "@rmwc/base": "^5.7.2",
-        "@rmwc/icon": "^5.7.2",
-        "@rmwc/provider": "^5.7.2",
-        "@rmwc/ripple": "^5.7.2",
-        "@rmwc/types": "^5.6.0"
-      }
-    },
-    "@rmwc/circular-progress": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@rmwc/circular-progress/-/circular-progress-5.7.2.tgz",
-      "integrity": "sha512-VNlf+orczwxL4ZqqOs9QYZRTQgQA9GaRsEIiKBnRQylRcy5TFm1AfSOzjL3LPLqnx2vrxYLmbVNe41BU3Tco0w==",
-      "requires": {
-        "@rmwc/base": "^5.7.2",
-        "@rmwc/types": "^5.6.0"
       }
     },
     "@rmwc/icon": {
@@ -1904,7 +2007,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
       "requires": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -2019,12 +2121,15 @@
         "@types/react": "*"
       }
     },
-    "@types/react-wait": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/react-wait/-/react-wait-0.3.1.tgz",
-      "integrity": "sha512-BS9AEjWZItDgpx6LlICcuf53M27zBFCsHx/llCbrmrt/WI7ecG2LGquCss3n8O8bwEDiTX4yYLjy8yLeIfgYTg==",
+    "@types/react-redux": {
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.16.tgz",
+      "integrity": "sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==",
       "requires": {
-        "@types/react": "*"
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/stack-utils": {
@@ -2302,6 +2407,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -2794,6 +2904,42 @@
       "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
       "requires": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-emotion": {
+      "version": "9.2.11",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
+      "integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/babel-utils": "^0.6.4",
+        "@emotion/hash": "^0.6.2",
+        "@emotion/memoize": "^0.6.1",
+        "@emotion/stylis": "^0.7.0",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "find-root": "^1.1.0",
+        "mkdirp": "^0.5.1",
+        "source-map": "^0.5.7",
+        "touch": "^2.0.1"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+          "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
+        },
+        "@emotion/stylis": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
+          "integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
       }
     },
     "babel-plugin-istanbul": {
@@ -3366,6 +3512,15 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -3669,6 +3824,11 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "codemirror": {
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.60.0.tgz",
+      "integrity": "sha512-AEL7LhFOlxPlCL8IdTcJDblJm8yrAGib7I+DErJPdZd4l6imx8IMgKK3RblVgBQqz3TZJR4oknQ03bz+uNjBYA=="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -3794,6 +3954,11 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "compute-scroll-into-view": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3963,6 +4128,37 @@
         "elliptic": "^6.0.0"
       }
     },
+    "create-emotion": {
+      "version": "9.2.12",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
+      "integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
+      "requires": {
+        "@emotion/hash": "^0.6.2",
+        "@emotion/memoize": "^0.6.1",
+        "@emotion/stylis": "^0.7.0",
+        "@emotion/unitless": "^0.6.2",
+        "csstype": "^2.5.2",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+          "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
+        },
+        "@emotion/stylis": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
+          "integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
+        },
+        "@emotion/unitless": {
+          "version": "0.6.7",
+          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
+          "integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
+        }
+      }
+    },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -4051,6 +4247,14 @@
       "integrity": "sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==",
       "requires": {
         "postcss": "^7.0.5"
+      }
+    },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "css-color-keywords": {
@@ -4342,6 +4546,11 @@
         }
       }
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -4613,6 +4822,14 @@
         "utila": "~0.4"
       }
     },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
@@ -4697,6 +4914,17 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "downshift": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-3.4.8.tgz",
+      "integrity": "sha512-dZL3iNL/LbpHNzUQAaVq/eTD1ocnGKKjbAl/848Q0KEp6t81LJbS37w3f93oD6gqqAnjdgM7Use36qZSipHXBw==",
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "compute-scroll-into-view": "^1.0.9",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -4779,6 +5007,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+    },
+    "emotion": {
+      "version": "9.2.12",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.12.tgz",
+      "integrity": "sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==",
+      "requires": {
+        "babel-plugin-emotion": "^9.2.11",
+        "create-emotion": "^9.2.12"
+      }
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -5881,6 +6118,11 @@
         "pkg-dir": "^3.0.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -6154,6 +6396,16 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -6401,6 +6653,19 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -8738,6 +9003,11 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -9268,6 +9538,14 @@
       "integrity": "sha512-lgAmPv9eYZ0bGwUYAKlr8MG6K4CvWliWqnkcT2P8mMAgVrH3lqfBPorFlxiG1pHQnqmavJZ9vbMXUTNyMLbrgQ==",
       "requires": {
         "semver": "^6.3.0"
+      }
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "requires": {
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -9809,6 +10087,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "pegjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -9875,11 +10158,26 @@
       }
     },
     "polished": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.4.4.tgz",
-      "integrity": "sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.1.1.tgz",
+      "integrity": "sha512-4MZTrfPMPRLD7ac8b+2JZxei58zw6N1hFkdBDERif5Tlj19y3vPoPusrLG+mJIlPTGnUlKw3+yWz0BazvMx1vg==",
       "requires": {
-        "@babel/runtime": "^7.6.3"
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "portfinder": {
@@ -11090,6 +11388,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "raf-schd": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.2.tgz",
+      "integrity": "sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ=="
+    },
     "ramda": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
@@ -11160,6 +11463,17 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "rc-pagination": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-1.21.1.tgz",
+      "integrity": "sha512-Z+iYLbrJOBKHdgoAjLhL9jOgb7nrbPzNmV31p0ikph010/Ov1+UkrauYzWhumUyR+GbRFi3mummdKW/WtlOewA==",
+      "requires": {
+        "babel-runtime": "6.x",
+        "classnames": "^2.2.6",
+        "prop-types": "^15.5.7",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
     "rc-tooltip": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.7.3.tgz",
@@ -11219,6 +11533,40 @@
         "regenerator-runtime": "^0.13.3",
         "whatwg-fetch": "^3.0.0"
       }
+    },
+    "react-beautiful-dnd": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
+      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
+      }
+    },
+    "react-codemirror2": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-5.1.0.tgz",
+      "integrity": "sha512-Cksbgbviuf2mJfMyrKmcu7ycK6zX/ukuQO8dvRZdFWqATf5joalhjFc6etnBdGCcPA2LbhIwz+OPnQxLN/j1Fw=="
     },
     "react-dev-utils": {
       "version": "10.2.0",
@@ -11386,10 +11734,13 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.6.tgz",
       "integrity": "sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw=="
     },
-    "react-fast-compare": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    "react-input-autosize": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
     },
     "react-is": {
       "version": "16.12.0",
@@ -11407,6 +11758,39 @@
       "integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
       "requires": {
         "prop-types": "^15.5.8"
+      }
+    },
+    "react-redux": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.3.tgz",
+      "integrity": "sha512-ZhAmQ1lrK+Pyi0ZXNMUZuYxYAZd59wFuVDGUt536kSGdD0ya9Q7BfsE95E3TsFLE3kOSFp5m6G5qbatE+Ic1+w==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/react-redux": "^7.1.16",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "react-scripts": {
@@ -11528,13 +11912,40 @@
         }
       }
     },
-    "react-table": {
-      "version": "7.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.0.0-rc.16.tgz",
-      "integrity": "sha512-2wcGKO56gKlE1IwJnFatCn1yzHIAwRgbTJJQeoSiERJ/Ed6VeLdJLMJkLuSnxZCwD8CjhZD+C/iXEaFubJVW3A==",
+    "react-select": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-2.4.4.tgz",
+      "integrity": "sha512-C4QPLgy9h42J/KkdrpVxNmkY6p4lb49fsrbDk/hRcZpX7JvZPNb6mGj+c5SzyEtBv1DmQ9oPH4NmhAFvCrg8Jw==",
       "requires": {
-        "@babel/plugin-transform-runtime": "^7.8.3"
+        "classnames": "^2.2.5",
+        "emotion": "^9.1.2",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "raf": "^3.4.0",
+        "react-input-autosize": "^2.2.1",
+        "react-transition-group": "^2.2.1"
       }
+    },
+    "react-table": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.6.3.tgz",
+      "integrity": "sha512-hfPF13zDLxPMpLKzIKCE8RZud9T/XrRTsaCIf8zXpWZIZ2juCl7qrGpo3AQw9eAetXV5DP7s2GDm+hht7qq5Dw=="
+    },
+    "react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "requires": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
     },
     "react-use": {
       "version": "13.27.0",
@@ -11556,10 +11967,14 @@
         "tslib": "^1.10.0"
       }
     },
-    "react-wait": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/react-wait/-/react-wait-0.3.0.tgz",
-      "integrity": "sha512-kB5x/kMKWcn0uVr9gBdNz21/oGbQwEQnF3P9p6E9yLfJ9DRcKS0fagbgYMFI0YFOoyKDj+2q6Rwax0kTYJF37g=="
+    "react-window": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
+      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      }
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -11621,6 +12036,15 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
+      }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regenerate": {
@@ -11868,6 +12292,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -12384,6 +12813,23 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "dependencies": {
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        }
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -13092,6 +13538,11 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.0.tgz",
       "integrity": "sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw=="
     },
+    "stylis-rule-sheet": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -13418,6 +13869,11 @@
         "loader-utils": "^1.0.3"
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -13654,6 +14110,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -13720,6 +14186,14 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
       "dev": true
+    },
+    "touch": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
+      "integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
+      "requires": {
+        "nopt": "~1.0.10"
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -14037,6 +14511,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "use-memo-one": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -14096,6 +14575,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": ".",
   "dependencies": {
     "@material/list": "^5.1.0",
-    "@netdata/netdata-ui": "^0.7.23",
+    "@netdata/netdata-ui": "^1.4.3",
     "@rmwc/icon": "^5.7.2",
     "@rmwc/list": "^5.7.2",
     "@rmwc/tooltip": "^5.7.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,36 @@
-import React from "react"
-import { ThemeProvider } from "styled-components"
-import { DefaultTheme } from "@netdata/netdata-ui"
+import React from "react";
+import { ThemeProvider } from "styled-components";
+import { DarkTheme, DefaultTheme } from "@netdata/netdata-ui";
 
-import { SignInButton } from "iframes/sign-in-button"
-import { SpacesBar } from "iframes/space-bar"
-import { SpacePanel } from "iframes/space-panel"
+import { SignInButton } from "iframes/sign-in-button";
+import { SpacesBar } from "iframes/space-bar";
+import { SpacePanel } from "iframes/space-panel";
+
+import SpacesBarV2 from "iframes/version2/spaceBar";
+import SpacePanelV2 from "iframes/version2/spacePanel";
+import SignOutV2 from 'iframes/version2/signOut'
 
 // const IS_DEVELOPMENT = process.env.NODE_ENV === "development"
 
-const SIGN_IN = "sign-in"
-const SPACE_PANEL = "space-panel"
-const SPACE_BAR = "space-bar"
+const SIGN_IN = "sign-in";
+const SIGN_OUT = "sign-out"
+const SPACE_PANEL = "space-panel";
+const SPACE_BAR = "space-bar";
 
 export const App = () => {
-  let path = window.location.pathname.replace("/", "")
-  path = path.replace("sso/", "")
+  let path = window.location.pathname.replace("/", "");
+  const isVersion2 = window.location.pathname.includes("v2");
+
+  path = path.replace("sso/", "").replace("v2/", "");
 
   return (
-    <ThemeProvider theme={DefaultTheme}>
+    <ThemeProvider theme={isVersion2 ? DarkTheme : DefaultTheme}>
       {path === SIGN_IN && <SignInButton />}
-      {path === SPACE_BAR && <SpacesBar />}
-      {path === SPACE_PANEL && <SpacePanel />}
+      {!isVersion2 && path === SPACE_BAR && <SpacesBar />}
+      {!isVersion2 && path === SPACE_PANEL && <SpacePanel />}
+      {isVersion2 && path === SPACE_BAR && <SpacesBarV2 />}
+      {isVersion2 && path === SPACE_PANEL && <SpacePanelV2 />}
+      {isVersion2 && path === SIGN_OUT && <SignOutV2 />}
     </ThemeProvider>
-  )
-}
+  );
+};

--- a/src/components/menus/index.js
+++ b/src/components/menus/index.js
@@ -1,0 +1,3 @@
+export { default as MenuItem, PanelRowContainer } from "./item"
+export { default as MenuList, DefaultListHeader } from "./list"
+export * from "./styled"

--- a/src/components/menus/item.js
+++ b/src/components/menus/item.js
@@ -1,0 +1,69 @@
+import React, { useCallback, forwardRef } from "react"
+import styled from "styled-components"
+import { getColor, Flex, Icon, Text } from "@netdata/netdata-ui"
+
+export const PanelRowContainer = styled(Flex)`
+  cursor: pointer;
+
+  &:hover {
+    background: ${getColor("selected")};
+  }
+
+  ${props => props.selected && `background: ${getColor("selected")(props)};`}
+`
+
+const MenuItem = forwardRef(
+  (
+    {
+      disabled,
+      children,
+      Wrapper = Text,
+      onClick,
+      testid,
+      icon,
+      padding = [2, 3],
+      margin = [0],
+      round = 0,
+      actions,
+      selected,
+      width = "100%",
+    },
+    ref
+  ) => {
+    const click = useCallback(() => {
+      if (disabled) return
+      if (onClick) onClick()
+    }, [onClick, disabled])
+
+    return (
+      <PanelRowContainer
+        ref={ref}
+        flexWrap={false}
+        justifyContent="between"
+        alignItems="center"
+        padding={padding}
+        margin={margin}
+        round={round}
+        onClick={click}
+        data-testid={testid}
+        width={width}
+        selected={selected}
+        disabled={disabled}
+      >
+        <Flex alignItems="center" gap={3} flex basis="">
+          {typeof icon === "string" ? (
+            <Icon name={icon} disabled={disabled} color="text" height="16px" width="16px" />
+          ) : (
+            icon
+          )}
+          <Wrapper opacity={disabled ? "medium" : undefined} width="150px">
+            {children}
+          </Wrapper>
+        </Flex>
+        {actions}
+      </PanelRowContainer>
+    )
+  }
+)
+
+export default MenuItem

--- a/src/components/menus/list.js
+++ b/src/components/menus/list.js
@@ -1,0 +1,22 @@
+import React from "react"
+import styled from "styled-components"
+import { Flex, H4, Collapsible } from "@netdata/netdata-ui"
+
+export const DefaultListHeader = styled(H4).attrs({ padding: [0], margin: [0] })`
+  cursor: pointer;
+`
+
+const SectionHandle = ({ toggleOpen, label, testid, Header = DefaultListHeader }) => (
+  <Header data-testid={testid} onClick={toggleOpen}>
+    {label}
+  </Header>
+)
+
+const ItemsList = ({ isOpen = false, toggleOpen, label, children, testid, Header }) => (
+  <Flex column>
+    <SectionHandle Header={Header} toggleOpen={toggleOpen} label={label} testid={testid} />
+    <Collapsible open={isOpen}>{() => children}</Collapsible>
+  </Flex>
+)
+
+export default ItemsList

--- a/src/components/menus/styled.js
+++ b/src/components/menus/styled.js
@@ -1,0 +1,9 @@
+import styled from "styled-components"
+import { getColor, getSizeBy } from "@netdata/netdata-ui"
+
+export const Divider = styled.div`
+  background: ${getColor("disabled")};
+  height: 1px;
+  width: auto;
+  margin: ${getSizeBy(1)} ${getSizeBy(3)};
+`

--- a/src/iframes/sign-in-button/sign-in-button.tsx
+++ b/src/iframes/sign-in-button/sign-in-button.tsx
@@ -273,6 +273,9 @@ export const SignInButton = () => {
       })
   }, [resetAccount, resetNodes, resetRooms, resetSpaces])
 
+  useListenToPostMessage("sign-out", () => {
+    handleLogoutClick()
+  });
 
   return (
     <StyledButtonContainer>

--- a/src/iframes/space-panel/components/replicated-nodes/styled.ts
+++ b/src/iframes/space-panel/components/replicated-nodes/styled.ts
@@ -19,7 +19,7 @@ export const NodesContainer = styled.div`
   }
 `
 
-export const ListHeaderContainer = styled(H5.withComponent("div"))`
+export const ListHeaderContainer = styled(H5)`
   text-shadow: unset;
   color: ${getColor(["borderColor"])};
 `

--- a/src/iframes/space-panel/components/space-rooms/room-label/room-label.tsx
+++ b/src/iframes/space-panel/components/space-rooms/room-label/room-label.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React from "react";
 import {
   StyledIcon,
   Container,
@@ -7,43 +7,42 @@ import {
   ErrorIndicator,
   WarningIndicator,
   UnreachableIndicator,
-} from "./styled"
+} from "./styled";
 
 interface Props {
-  alarmCounter: {
-    critical: number
-    warning: number
-  } | undefined
-  unreachableCount: number
-  room: any
-  spaceSlug: string
+  alarmCounter:
+    | {
+        critical: number;
+        warning: number;
+      }
+    | undefined;
+  unreachableCount: number;
+  room: any;
+  spaceSlug: string;
 }
 
 export const RoomLabel = ({
-  alarmCounter, room, spaceSlug, unreachableCount,
+  alarmCounter,
+  room,
+  spaceSlug,
+  unreachableCount,
 }: Props) => {
   const handleSelectRoom = () => {
     // navigate to cloud room
-  }
-  const href = `/spaces/${spaceSlug}/rooms/${room.slug}`
+  };
+  const href = `/spaces/${spaceSlug}/rooms/${room.slug}`;
 
   return (
     <Container onClick={handleSelectRoom}>
       <StyledIcon name="room" />
-      <RoomName href={href} target="_PARENT">
+      <RoomName as="a" href={href} target="_PARENT">
         {room.name}
       </RoomName>
       <IndicatorsContainer>
-        {alarmCounter && alarmCounter.critical > 0 && (
-          <ErrorIndicator />
-        )}
-        {alarmCounter && alarmCounter.warning > 0 && (
-          <WarningIndicator />
-        )}
-        {unreachableCount > 0 && (
-          <UnreachableIndicator />
-        )}
+        {alarmCounter && alarmCounter.critical > 0 && <ErrorIndicator />}
+        {alarmCounter && alarmCounter.warning > 0 && <WarningIndicator />}
+        {unreachableCount > 0 && <UnreachableIndicator />}
       </IndicatorsContainer>
     </Container>
-  )
-}
+  );
+};

--- a/src/iframes/space-panel/components/space-rooms/room-label/styled.ts
+++ b/src/iframes/space-panel/components/space-rooms/room-label/styled.ts
@@ -20,7 +20,7 @@ export const Container = styled.div`
   }
 `
 
-export const RoomName = styled(Text.withComponent("a"))`
+export const RoomName = styled(Text)`
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/iframes/space-panel/components/visited-nodes/styled.ts
+++ b/src/iframes/space-panel/components/visited-nodes/styled.ts
@@ -23,7 +23,7 @@ export const NodesContainer = styled.div`
   }
 `
 
-export const ListHeaderContainer = styled(H5.withComponent("div"))`
+export const ListHeaderContainer = styled(H5)`
   text-shadow: unset;
   color: ${getColor(["borderColor"])};
 `
@@ -55,7 +55,7 @@ export const StyledIcon = styled(Icon)`
   fill: ${getColor(["text"])};
 `
 
-export const NodeUrl = styled(TextNano.withComponent("a"))`
+export const NodeUrl = styled(TextNano)`
   margin-left: ${getSizeBy(5)};
   font-size: 11px;
   color: #aeb3b7;

--- a/src/iframes/space-panel/components/visited-nodes/visited-nodes.tsx
+++ b/src/iframes/space-panel/components/visited-nodes/visited-nodes.tsx
@@ -41,7 +41,7 @@ const Node = ({ agent: { name, urls }, onDeleteClick }: NodeProps) => (
         // eslint-disable-next-line react/no-array-index-key
         key={i}
       >
-        <NodeUrl href={url} target="_PARENT">
+        <NodeUrl as="a" href={url} target="_PARENT">
           {url}
         </NodeUrl>
         <TrashIcon

--- a/src/iframes/version2/signOut/index.js
+++ b/src/iframes/version2/signOut/index.js
@@ -1,0 +1,21 @@
+import React, { useCallback } from "react";
+import styled from "styled-components";
+import { Text } from "@netdata/netdata-ui";
+import { useFocusDetector } from "hooks/use-focus-detector";
+import { sendToIframes } from "utils/post-message";
+
+const Button = styled(Text)`
+  cursor: pointer;
+`;
+
+const SignOut = () => {
+  useFocusDetector();
+
+  const signOut = useCallback(() => {
+    sendToIframes({ type: "sign-out", payload: true });
+  }, []);
+
+  return <Button onClick={signOut}>Sign out</Button>;
+};
+
+export default SignOut;

--- a/src/iframes/version2/spaceBar/index.js
+++ b/src/iframes/version2/spaceBar/index.js
@@ -1,0 +1,87 @@
+import React, { useState, useEffect } from "react";
+import { useMount } from "react-use";
+import { Button, Flex } from "@netdata/netdata-ui";
+import { sendToIframes, useListenToPostMessage } from "utils/post-message";
+import { useFocusDetector } from "hooks/use-focus-detector";
+import SpaceLabel from "./spaceLabel";
+
+const SpacesBar = () => {
+  useFocusDetector();
+  useMount(() => {
+    sendToIframes({
+      type: "hello-from-spaces-bar",
+      payload: true,
+    });
+  });
+  const spacesResult = useListenToPostMessage("spaces");
+  const spaces = spacesResult?.results;
+
+  // duplicated state! if additional logic will be added it's better to use sign-in-button
+  // activeSpaceID state
+  const [activeSpaceID, setActiveSpaceID] = useState("");
+
+  useEffect(() => {
+    if (!activeSpaceID && spacesResult && !!spacesResult.results.length) {
+      setActiveSpaceID(spacesResult.results[0].id);
+    }
+  }, [activeSpaceID, spacesResult]);
+
+  const handleSpaceIconClick = (spaceId) => {
+    setActiveSpaceID(spaceId);
+    sendToIframes({
+      type: "space-change",
+      payload: spaceId,
+    });
+  };
+
+  return (
+    <Flex
+      column
+      justifyContent="between"
+      padding={[3, 0]}
+      width="64px"
+      alignItems="center"
+      gap={4}
+      overflow="hidden"
+    >
+      <Flex column gap={2}>
+        {spaces && spaces.length ? (
+          spaces.map((space) => {
+            const isActive = space.id === activeSpaceID;
+            return (
+              <SpaceLabel
+                onSpaceIconClick={handleSpaceIconClick}
+                key={space.id}
+                space={space}
+                active={isActive}
+              />
+            );
+          })
+        ) : (
+          <Flex
+            width="40px"
+            height="40px"
+            round={2}
+            border={{
+              side: "all",
+              color: "border",
+              size: "2px",
+              type: "dotted",
+            }}
+          />
+        )}
+      </Flex>
+      <Flex height="1px" background="separator" width="20px" />
+      <Button
+        icon="plus"
+        onClick={() => {
+          window.top.window.location.href = `/spaces/${
+            spaces?.[0]?.slug || "any"
+          }/rooms/general?modal=createSpace`;
+        }}
+      />
+    </Flex>
+  );
+};
+
+export default SpacesBar;

--- a/src/iframes/version2/spaceBar/spaceLabel/index.js
+++ b/src/iframes/version2/spaceBar/spaceLabel/index.js
@@ -1,0 +1,37 @@
+import React, { useCallback } from "react";
+import { Text } from "@netdata/netdata-ui";
+import { Tooltip } from "@rmwc/tooltip";
+import "@rmwc/tooltip/tooltip.css";
+import SpaceBox from "./spaceBox";
+
+const getSpaceInitials = (name) => {
+  const splittedName = name.split(" ");
+  const [firstSubstring, secondSubstring] = splittedName;
+  const firstLetter = firstSubstring[0];
+  const secondLetter = secondSubstring ? secondSubstring[0] : "";
+  return [firstLetter, secondLetter];
+};
+
+const SpaceLabel = ({ space, active, onSpaceIconClick }) => {
+  const [firstLetter, secondLetter] = getSpaceInitials(space.name);
+
+  const onClick = useCallback(() => onSpaceIconClick(space.id), [
+    space.id,
+    onSpaceIconClick,
+  ]);
+
+  return (
+    <Tooltip content={space.name || ""} align="right">
+      <SpaceBox active={active} onClick={onClick}>
+        <Text strong color={active ? "main" : "border"}>
+          {firstLetter}
+        </Text>
+        <Text strong color={active ? "border" : "separator"}>
+          {secondLetter}
+        </Text>
+      </SpaceBox>
+    </Tooltip>
+  );
+};
+
+export default SpaceLabel;

--- a/src/iframes/version2/spaceBar/spaceLabel/spaceBox.js
+++ b/src/iframes/version2/spaceBar/spaceLabel/spaceBox.js
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+import { Flex } from "@netdata/netdata-ui";
+
+const SpaceBox = styled(Flex).attrs(({ active }) => ({
+  width: 10,
+  height: 10,
+  background: active ? "separator" : "elementBackground",
+  justifyContent: "center",
+  alignItems: "center",
+  round: 2,
+}))`
+  cursor: pointer;
+`;
+
+export default SpaceBox;

--- a/src/iframes/version2/spacePanel/index.js
+++ b/src/iframes/version2/spacePanel/index.js
@@ -1,0 +1,59 @@
+import React from "react";
+import { useMount } from "react-use";
+import { Flex, H4 } from "@netdata/netdata-ui";
+import { useFocusDetector } from "hooks/use-focus-detector";
+import SpaceRooms from "./rooms";
+import ReplicatedNodes from "./nodes/replicatedNodes";
+import VisitedNodes from "./nodes/visitedNodes";
+import {
+  sendToParent,
+  sendToIframes,
+  useListenToPostMessage,
+} from "utils/post-message";
+
+const SpacePanel = () => {
+  useFocusDetector();
+
+  useMount(() => {
+    sendToIframes({
+      type: "hello-from-space-panel",
+      payload: true,
+    });
+    sendToParent({
+      type: "hello-from-space-panel",
+      payload: true,
+    });
+  });
+
+  const rooms = useListenToPostMessage("rooms");
+  const streamedHostsData = useListenToPostMessage("streamed-hosts-data");
+  const visitedNodes = useListenToPostMessage("visited-nodes");
+  const alarms = useListenToPostMessage("alarms") || [];
+
+  const handleDeleteNode = (nodeId, url) => {
+    sendToIframes({
+      type: "delete-node-request",
+      payload: { nodeId, url },
+    });
+  };
+
+  return (
+    <Flex flex overflow={{ vertical: "auto" }} column>
+      {rooms && <H4>{rooms.spaceName}</H4>}
+      {rooms && !!rooms.results.length && (
+        <SpaceRooms rooms={rooms} alarms={alarms} />
+      )}
+      {streamedHostsData && !!streamedHostsData.replicatedNodes.length && (
+        <ReplicatedNodes replicatedNodes={streamedHostsData} />
+      )}
+      {visitedNodes && visitedNodes.length > 0 && (
+        <VisitedNodes
+          onDeleteClick={handleDeleteNode}
+          visitedNodes={visitedNodes}
+        />
+      )}
+    </Flex>
+  );
+};
+
+export default SpacePanel;

--- a/src/iframes/version2/spacePanel/nodes/replicatedNodes/index.js
+++ b/src/iframes/version2/spacePanel/nodes/replicatedNodes/index.js
@@ -1,0 +1,95 @@
+import React, { useState, useCallback, useMemo } from "react";
+import styled from "styled-components";
+import { Text, Flex, Icon, TextInput } from "@netdata/netdata-ui";
+import { MenuList } from "components/menus";
+import { alwaysEndWithSlash } from "utils/always-end-with-slash";
+import Pill from "./pill";
+import { StyledIcon } from "../../styled";
+
+const Search = styled(TextInput)`
+  & > label {
+    margin-bottom: 0;
+  }
+`;
+
+const ReplicatedNodes = ({
+  replicatedNodes: { parentNode, replicatedNodes },
+}) => {
+  const [listOpen, setListOpen] = useState(true);
+  const [value, setValue] = useState("");
+
+  const toggleListOpen = useCallback(() => setListOpen((o) => !o), []);
+  const onChange = useCallback((e) => setValue(e.target.value), []);
+
+  const nodes = useMemo(() => {
+    if (!value) return replicatedNodes;
+    return replicatedNodes.filter(({ hostname }) =>
+      hostname.toLowerCase().includes(value.toLowerCase())
+    );
+  }, [replicatedNodes, value]);
+
+  return (
+    <MenuList
+      isOpen={listOpen}
+      toggleOpen={toggleListOpen}
+      label={
+        <Flex padding={[2, 0]} flex alignItems="center" gap={3}>
+          <StyledIcon
+            right={!listOpen}
+            name="chevron_down"
+            size="small"
+            color="text"
+          />
+          <Text>Replicated Nodes</Text>
+        </Flex>
+      }
+    >
+      <Flex column gap={3} padding={[2, 0]}>
+        <Flex
+          gap={2}
+          as="a"
+          href={parentNode.url}
+          target="_PARENT"
+          padding={[2, 0, 0, 4]}
+        >
+          <Icon name="nodes" size="small" color="bright" />
+          <Text color="bright">{parentNode.hostname}</Text>
+        </Flex>
+        {nodes.length >= 5 && (
+          <Flex padding={[0, 0, 0, 6]}>
+            <Search
+              value={value}
+              onChange={onChange}
+              iconLeft={<Icon name="search_s" size="small" color="text" />}
+              metaShrinked
+            />
+          </Flex>
+        )}
+        {nodes.map(({ hostname, url, status }) => (
+          <Flex
+            as="a"
+            href={alwaysEndWithSlash(url)}
+            target="_PARENT"
+            key={hostname}
+            padding={[0, 0, 0, 6]}
+            gap={2}
+            alignItems="center"
+            justifyContent="between"
+          >
+            <Flex alignItems="center" gap={2}>
+              <Icon name="node" color="bright" />
+              <Text color="bright" truncate>
+                {hostname}
+              </Text>
+            </Flex>
+            <Pill background={status ? "success" : "border"} color="bright">
+              {status ? "LIVE" : "OFF"}
+            </Pill>
+          </Flex>
+        ))}
+      </Flex>
+    </MenuList>
+  );
+};
+
+export default ReplicatedNodes;

--- a/src/iframes/version2/spacePanel/nodes/replicatedNodes/pill.js
+++ b/src/iframes/version2/spacePanel/nodes/replicatedNodes/pill.js
@@ -1,0 +1,20 @@
+import React, { forwardRef } from "react";
+import styled from "styled-components";
+import { Flex, TextMicro } from "@netdata/netdata-ui";
+
+const StyledPill = styled(Flex).attrs({
+  padding: [0.5, 1],
+  round: 1,
+})`
+  cursor: pointer;
+`;
+
+const Pill = forwardRef(({ children, background, color, ...rest }, ref) => (
+  <StyledPill background={background} ref={ref} {...rest}>
+    <TextMicro color={color} strong>
+      {children}
+    </TextMicro>
+  </StyledPill>
+));
+
+export default Pill;

--- a/src/iframes/version2/spacePanel/nodes/visitedNodes/index.js
+++ b/src/iframes/version2/spacePanel/nodes/visitedNodes/index.js
@@ -1,0 +1,40 @@
+import React, { useCallback, useState } from "react";
+import { Flex, Text } from "@netdata/netdata-ui";
+import { MenuList } from "components/menus";
+import { StyledIcon } from "../../styled";
+import Node from './node'
+
+const VisitedNodes = ({ onDeleteClick, visitedNodes }) => {
+  const [listOpen, setListOpen] = useState(true);
+  const toggleListOpen = useCallback(() => setListOpen((o) => !o), []);
+
+  return (
+    <MenuList
+      isOpen={listOpen}
+      toggleOpen={toggleListOpen}
+      label={
+        <Flex padding={[2, 0]} flex alignItems="center" gap={3}>
+          <StyledIcon
+            right={!listOpen}
+            name="chevron_down"
+            size="small"
+            color="text"
+          />
+          <Text>Visited Nodes</Text>
+        </Flex>
+      }
+    >
+      <Flex column gap={3} padding={[2, 0, 0, 4]}>
+        {visitedNodes.map((agent) => (
+          <Node
+            key={agent.id}
+            onDeleteClick={(url) => onDeleteClick(agent.id, url)}
+            agent={agent}
+          />
+        ))}
+      </Flex>
+    </MenuList>
+  );
+};
+
+export default VisitedNodes;

--- a/src/iframes/version2/spacePanel/nodes/visitedNodes/node.js
+++ b/src/iframes/version2/spacePanel/nodes/visitedNodes/node.js
@@ -1,0 +1,51 @@
+import React, { useState, useCallback } from "react";
+import { Flex, Text, TextSmall, Icon } from "@netdata/netdata-ui";
+import { MenuList } from "components/menus";
+import { StyledIcon } from "../../styled";
+
+const Node = ({ agent: { name, urls } }, onDeleteClick) => {
+  const [listOpen, setListOpen] = useState(false);
+  const toggleListOpen = useCallback(() => setListOpen((o) => !o), []);
+  return (
+    <MenuList
+      isOpen={listOpen}
+      toggleOpen={toggleListOpen}
+      label={
+        <Flex flex alignItems="center" gap={3}>
+          <Text>{name}</Text>
+          <StyledIcon
+            right={!listOpen}
+            name="chevron_down"
+            size="small"
+            color="text"
+          />
+        </Flex>
+      }
+    >
+      {urls.map((url) => (
+        <Flex
+          flex
+          alignItems="center"
+          justifyContent="between"
+          padding={[2, 0, 0, 2]}
+        >
+          <Flex alignItems="center" gap={2}>
+            <Icon name="node" color="bright" />
+            <TextSmall as="a" href={url} target="_Parent">
+              {url}
+            </TextSmall>
+          </Flex>
+          <Icon
+            name="trashcan"
+            size="small"
+            color="text"
+            onClick={() => {
+              onDeleteClick(url);
+            }}
+          />
+        </Flex>
+      ))}
+    </MenuList>
+  );
+};
+export default Node;

--- a/src/iframes/version2/spacePanel/rooms/index.js
+++ b/src/iframes/version2/spacePanel/rooms/index.js
@@ -1,0 +1,70 @@
+import React, { useCallback, useState } from "react";
+import { Text, Button, Flex } from "@netdata/netdata-ui";
+import { MenuList } from "components/menus";
+import RoomLabel from "./roomLabel";
+import { StyledIcon } from "../styled";
+
+const mockedWorkspace = {};
+
+const SpaceRooms = ({ alarms, rooms }) => {
+  const [listOpen, setListOpen] = useState(true);
+  const workspace = mockedWorkspace;
+  const isAllowedToCreateRooms = !workspace.createRoomAdminsOnly || true;
+
+  const handleAddRoom = (e) => {
+    e.preventDefault();
+    // eslint-disable-next-line max-len
+    window.top.window.location.href = `/spaces/${rooms.spaceSlug}/rooms/general?modal=createRoom`;
+  };
+
+  const toggleListOpen = useCallback(() => setListOpen((o) => !o), []);
+
+  return (
+    <MenuList
+      isOpen={listOpen}
+      toggleOpen={toggleListOpen}
+      label={
+        <Flex
+          padding={[2, 0]}
+          flex
+          justifyContent="between"
+          alignItems="center"
+        >
+          <Flex alignItems="center" gap={3}>
+            <StyledIcon
+              right={!listOpen}
+              name="chevron_down"
+              size="small"
+              color="text"
+            />
+            <Text>Rooms</Text>
+          </Flex>
+          <Button
+            small
+            icon="plus"
+            onClick={handleAddRoom}
+            data-testid="workspaceRooms-addWarRoom-button"
+            disabled={!isAllowedToCreateRooms}
+          />
+        </Flex>
+      }
+    >
+      <Flex column gap={2}>
+        {rooms.results.map((room) => {
+          const roomAlarms = alarms.find((alarm) => alarm.roomID === room.id);
+          return (
+            <RoomLabel
+              key={room.id}
+              room={room}
+              spaceSlug={rooms.spaceSlug}
+              alarmCounter={roomAlarms?.alarmCounter}
+              unreachableCount={roomAlarms?.unreachableCount || 0}
+            />
+          );
+        })}
+      </Flex>
+    </MenuList>
+  );
+};
+
+export default SpaceRooms;

--- a/src/iframes/version2/spacePanel/rooms/roomLabel/index.js
+++ b/src/iframes/version2/spacePanel/rooms/roomLabel/index.js
@@ -1,0 +1,55 @@
+import React from "react";
+import styled from "styled-components";
+import { Flex, Text, Icon, getColor } from "@netdata/netdata-ui";
+
+const Indicator = styled(Flex).attrs({
+  width: "8px",
+  height: "8px",
+  round: 8,
+  justifyContent: "center",
+  alignItems: "center",
+})``;
+
+const Container = styled(Flex).attrs({
+  alignItems: "center",
+  padding: [0, 0, 0, 2],
+  round: true,
+})`
+  cursor: pointer;
+  &:hover {
+    background: ${getColor("selected")};
+  }
+`;
+
+const RoomLabel = ({ alarmCounter, room, spaceSlug, unreachableCount }) => {
+  const href = `/spaces/${spaceSlug}/rooms/${room.slug}`;
+  return (
+    <Container
+      alignItems="center"
+      justifyContent="between"
+      flex
+      padding={[0,0,0,2]}
+      height="32px"
+      round
+      as="a"
+      href={href}
+      target="_PARENT"
+    >
+      <Flex alignItems="center" gap={2}>
+        <Icon name="space_new" size="small" color="text" />
+        <Text truncate>{room.name}</Text>
+      </Flex>
+      <Flex gap={1}>
+        {alarmCounter && !!alarmCounter.critical && (
+          <Indicator background="error" />
+        )}
+        {alarmCounter && !!alarmCounter.warning && (
+          <Indicator background="warning" />
+        )}
+        {unreachableCount > 0 && <Indicator background="bombay" />}
+      </Flex>
+    </Container>
+  );
+};
+
+export default RoomLabel;

--- a/src/iframes/version2/spacePanel/styled.js
+++ b/src/iframes/version2/spacePanel/styled.js
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+import { Icon } from "@netdata/netdata-ui";
+
+export const StyledIcon = styled(Icon)`
+  transform: ${({ right }) => (right ? "rotate(270deg)" : "none")};
+`;

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@ html, body, #root {
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: hidden
 }
 
 code {

--- a/src/utils/post-message.ts
+++ b/src/utils/post-message.ts
@@ -26,6 +26,7 @@ type IframesMessageType =
   | "delete-node-request"
   | "space-change"
   | "synced-private-registry"
+  | "sign-out"
 
 interface IframesMessage<T = unknown> {
   type: IframesMessageType

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "baseUrl": "src",
     "target": "es5",

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "components/*": ["./src/components/*"]
+    }
+  }
+}


### PR DESCRIPTION
Cloud iframes to support agent redesign [here](https://github.com/netdata/dashboard/pull/254).

Created a version 2 of the components so that we don't break old users dashboards. The url is checked and if it contains `/v2` then it renders version2 iframes otherwise the old ones.