### PR TITLE
update visited nodes optimistically before upserting/touching

### DIFF
--- a/src/iframes/sign-in-button/optimistically-updated-visited-nodes.test.ts
+++ b/src/iframes/sign-in-button/optimistically-updated-visited-nodes.test.ts
@@ -1,0 +1,59 @@
+import update from "./optimistically-updated-visited-nodes"
+
+const now = new Date().toISOString()
+Date.prototype.toISOString = () => now
+
+const getVisitedNode = (nr: string) => ({
+  id: nr,
+  name: `name-${nr}`,
+  urls: [`https://url-${nr}`, `http://url-${nr}`],
+  accessCount: 2,
+  lastAccessTime: new Date().toISOString(),
+})
+
+describe("optimistically updated visited nodes", () => {
+  it("adds entry given empty visited nodes", () => {
+    expect(update([], "id1", "https://agent.url", "name1")).toEqual([
+      {
+        accessCount: 1,
+        id: "id1",
+        lastAccessTime: now,
+        urls: ["https://agent.url"],
+        name: "name1",
+      },
+    ])
+  })
+
+  it("finds finds visited node and moves it to the beginning", () => {
+    expect(
+      update(
+        [getVisitedNode("a"), getVisitedNode("b"), getVisitedNode("c")],
+        "b",
+        "https://new-url",
+        "new name"
+      )
+    ).toEqual([
+      {
+        accessCount: 3,
+        id: "b",
+        lastAccessTime: now,
+        name: "new name",
+        urls: ["https://url-b", "http://url-b"],
+      },
+      {
+        accessCount: 2,
+        id: "a",
+        lastAccessTime: now,
+        name: "name-a",
+        urls: ["https://url-a", "http://url-a"],
+      },
+      {
+        accessCount: 2,
+        id: "c",
+        lastAccessTime: now,
+        name: "name-c",
+        urls: ["https://url-c", "http://url-c"],
+      },
+    ])
+  })
+})

--- a/src/iframes/sign-in-button/optimistically-updated-visited-nodes.ts
+++ b/src/iframes/sign-in-button/optimistically-updated-visited-nodes.ts
@@ -1,0 +1,35 @@
+import { VisitedNodes } from "utils/types"
+
+const optimisticallyUpdatedVisitedNodes = (
+  visitedNodes: VisitedNodes,
+  id: string,
+  agentUrl: string,
+  name: string
+) => {
+  const visitedNode = visitedNodes.find(node => node.id === id)
+  const rest = visitedNodes.filter(node => node.id !== id)
+
+  if (!visitedNode)
+    return [
+      {
+        accessCount: 1,
+        id,
+        lastAccessTime: new Date().toISOString(),
+        urls: [agentUrl],
+        name,
+      },
+      ...rest,
+    ]
+
+  return [
+    {
+      ...visitedNode,
+      accessCount: visitedNode.accessCount + 1,
+      lastAccessTime: new Date().toISOString(),
+      name,
+    },
+    ...rest,
+  ]
+}
+
+export default optimisticallyUpdatedVisitedNodes

--- a/src/iframes/sign-in-button/sign-in-button.tsx
+++ b/src/iframes/sign-in-button/sign-in-button.tsx
@@ -161,6 +161,7 @@ export const SignInButton = () => {
           urls,
         })
         .then(() => setUpsertState("fulfilled"))
+        .catch(() => fetchNodesAgain())
     }
   }, [account, upsertState, id, name, nodes, origin])
 
@@ -169,7 +170,7 @@ export const SignInButton = () => {
     if (accoundID && upsertState === "fulfilled") {
       const touchUrl = `${cloudApiUrl}accounts/${accoundID}/nodes/${id}/touch`
       // no error handling is needed
-      axiosInstance.post(touchUrl, {})
+      axiosInstance.post(touchUrl, {}).catch(() => fetchNodesAgain())
     }
   }, [accoundID, id, upsertState])
 

--- a/src/iframes/sign-in-button/sign-in-button.tsx
+++ b/src/iframes/sign-in-button/sign-in-button.tsx
@@ -19,6 +19,7 @@ import { useFocusDetector } from "hooks/use-focus-detector"
 import { useUserNodeAccess } from "hooks/use-user-node-access"
 
 import { StyledButtonContainer, StyledSignInButton } from "./styles"
+import optimisticallyUpdatedVisitedNodes from "./optimistically-updated-visited-nodes"
 
 const TOKEN_EXPIRES_AT = "token_expires_at"
 
@@ -108,9 +109,9 @@ export const SignInButton = () => {
   })
 
   const redirectUri = encodeURIComponent(document.referrer)
-  const id = query.get("id")
-  const name = query.get("name")
-  const origin = query.get("origin")
+  const id = query.get("id")!
+  const name = query.get("name")!
+  const origin = query.get("origin")!
   const cloudSignInUrl =
     "/sign-in" + `?id=${id}&name=${name}&origin=${origin}&redirect_uri=${redirectUri}`
 
@@ -130,9 +131,10 @@ export const SignInButton = () => {
   )
   useEffect(() => {
     if (nodes && helloFromSpacePanel && account) {
+      const updated = optimisticallyUpdatedVisitedNodes(nodes.results, id, origin, name)
       sendToIframes({
         type: "visited-nodes",
-        payload: nodes.results,
+        payload: updated,
       })
     }
   }, [account, helloFromSpacePanel, nodes])
@@ -158,7 +160,6 @@ export const SignInButton = () => {
           name,
           urls,
         })
-        .then(fetchNodesAgain)
         .then(() => setUpsertState("fulfilled"))
     }
   }, [account, upsertState, id, name, nodes, origin])


### PR DESCRIPTION
Relates to https://github.com/netdata/cloud-frontend/issues/3040#issuecomment-1061570447

After "touch", the visited node was sometimes not first at the least. Use (almost) the same mechanism to optimistically update nodes before upsert/touch.
This also removes the need for second fetch after upserting
